### PR TITLE
Add instructions for sending a request to a webhook URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # MRKTO_webhooks
+
+## Sending a request to a webhook URL
+
+### Using `curl`
+
+To send a request to a webhook URL using `curl`, you can use the following command:
+
+```sh
+curl -X POST -H "Content-Type: application/json" -d '{"key1":"value1", "key2":"value2"}' https://your-webhook-url.com
+```
+
+This command sends a POST request with JSON data to the specified webhook URL.
+
+### Using Python
+
+To send a request to a webhook URL using Python, you can use the `requests` library. Here is an example script:
+
+```python
+import requests
+import json
+
+url = 'https://your-webhook-url.com'
+data = {
+    'key1': 'value1',
+    'key2': 'value2'
+}
+
+response = requests.post(url, data=json.dumps(data), headers={'Content-Type': 'application/json'})
+
+print(response.status_code)
+print(response.text)
+```
+
+This script sends a POST request with JSON data to the specified webhook URL and prints the response status code and text.


### PR DESCRIPTION
Add instructions for sending a request to a webhook URL in the `README.md` file.

* **Using `curl`**
  - Add a section explaining how to send a request to a webhook URL using `curl`.
  - Provide an example `curl` command to send a POST request with JSON data.

* **Using Python**
  - Add a section explaining how to send a request to a webhook URL using Python.
  - Provide an example Python script to send a POST request with JSON data using the `requests` library.
  - Include code to print the response status code and text.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MarcoLamolha/MRKTO_webhooks/pull/1?shareId=c5f3fbf0-2d25-43a5-8639-4b210d641745).